### PR TITLE
✨ feat: Add renderIcon prop to Button component

### DIFF
--- a/src/components/Button/Button.d.ts
+++ b/src/components/Button/Button.d.ts
@@ -7,6 +7,7 @@ declare module IButton {
     iconPosition?: "left" | "right" | "none";
     iconOnly: boolean;
     type: "submit" | "reset" | "button";
+    renderIcon: () => ReactNode;
     children: ReactNode;
   }
 }

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import Button from ".";
-
+import CustomIcon from "../CustomIcon";
 // More on how to set up stories at: https://storybook.js.org/docs/7.0/react/writing-stories/introduction
 const meta = {
   title: "Example/Button",
@@ -66,5 +66,8 @@ export const Default: Story = {
     type: "button",
     children: "button",
     iconOnly: false,
+    renderIcon: () => {
+      return <CustomIcon iconSize="md" iconName="add" />;
+    },
   },
 };

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -2,10 +2,10 @@ import classNames from "classnames";
 import { FC } from "react";
 import { IButton } from "./Button";
 import styles from "./Button.module.css";
-import CustomIcon from "../CustomIcon";
 const Button: FC<IButton.IProps> = ({
   size = "lg",
   iconPosition = "left",
+  renderIcon,
   iconOnly = false,
   variant,
   type = "button",
@@ -18,9 +18,9 @@ const Button: FC<IButton.IProps> = ({
   const hideButtonText = iconOnly === false;
   return (
     <button onClick={onClick} className={buttonClasses} type={type}>
-      {iconPosition === "left" && <CustomIcon iconSize="sm" iconName="add" />}
+      {iconPosition === "left" && renderIcon() }
       {hideButtonText ? <span>{children}</span> : null}
-      {iconPosition === "right" && <CustomIcon iconSize="sm" iconName="add" />}
+      {iconPosition === "right" && renderIcon() }
     </button>
   );
 };


### PR DESCRIPTION
The Button component now accepts a `renderIcon` prop, which is a function that returns a ReactNode. When this prop is provided, the icon will be rendered using the custom icon returned by this function. This feature was added by modifying the `Button` component and the `Button` story.