### PR TITLE
Enhance/encapsulate typography font styles

### DIFF
--- a/src/components/Typography/Typography.d.ts
+++ b/src/components/Typography/Typography.d.ts
@@ -6,9 +6,9 @@ declare namespace ITypography {
     fontSize: FontSizes;
     htmlTag: HeadingTag;
     children: string;
-    className?: string;
     fontWeight: FontWight;
     fontFamily: FontFamilies;
+    varient?: "sectionTitle" | "subSectionTitle" | "cardTitle" | "cardTag";
   }
 }
 

--- a/src/components/Typography/Typography.module.css
+++ b/src/components/Typography/Typography.module.css
@@ -1,3 +1,19 @@
+.sectionTitle {
+  @apply font-Montserrat text-4xl font-semibold text-black;
+}
+
+.subSectionTitle {
+  @apply font-Montserrat text-base font-normal text-blackishgreen;
+}
+
+.cardTitle {
+  @apply font-Montserrat text-lg font-semibold text-blackishgreen;
+}
+
+.cardTag {
+  @apply font-Montserrat text-base font-medium text-black;
+}
+
 .font-xs {
   @apply text-xs;
 }

--- a/src/components/Typography/Typography.stories.tsx
+++ b/src/components/Typography/Typography.stories.tsx
@@ -28,5 +28,6 @@ export const Default: Story = {
     fontFamily: "Montserrat",
     fontWeight: "bold",
     fontSize: "2xl",
+    varient: "cardTitle",
   },
 };

--- a/src/components/Typography/index.tsx
+++ b/src/components/Typography/index.tsx
@@ -6,10 +6,10 @@ import classNames from "classnames";
 const Typography: React.FC<ITypography.IProps> = ({
   children,
   fontSize = "2xl",
-  className = "",
   htmlTag: HtmlTag,
   fontFamily,
   fontWeight = "normal",
+  varient,
 }) => {
   const fontClassNames = classNames({
     "font-Montserrat": fontFamily === "Montserrat",
@@ -28,8 +28,15 @@ const Typography: React.FC<ITypography.IProps> = ({
     "text-4xl": fontSize === "4xl",
     "text-3xl": fontSize === "3xl",
     "text-2xl": fontSize === "2xl",
+    //variant
   });
-  return <HtmlTag className={fontClassNames}> {children}</HtmlTag>;
+  const varientClassName = styles[`${varient}`]??"";
+  return (
+    <HtmlTag className={`${varientClassName} ${fontClassNames}`}>
+      {" "}
+      {children}
+    </HtmlTag>
+  );
 };
 
 export default Typography;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,7 +8,7 @@ export default {
       white: "#ffffff",
       black: "#000000",
       blackishgreen: {
-        DEFAULT: "#11221",
+        DEFAULT: "#112211",
       },
       mintgreen: {
         DEFAULT: "#8DD3BB",
@@ -43,6 +43,11 @@ export default {
     fontFamily: {
       Montserrat: ["Montserrat"],
       Tradegothic: ["Tradegothic"],
+    },
+    boxShadow: {
+      "md-green-100": "0px 4px 16px rgba(17, 34, 17, 0.05)",
+      "md-teal-200": "0px 4px 16px rgba(141, 211, 187, 0.15)",
+      "lg-green-200": "2px 4px 16px rgba(17, 34, 17, 0.1)",
     },
     extend: {
       borderRadius: {


### PR DESCRIPTION
…nctionality

This commit adds a new optional `varient` prop to the `Typography` component that allows for different styles to be applied to typography elements. The possible values for this prop are `"sectionTitle"`, `"subSectionTitle"`, `"cardTitle"`, and `"cardTag"`. Additionally, the implementation of this new prop has been added to the `Typography` component, with corresponding CSS classes defined in the `Typography.module.css` file. Finally, the `tailwind.config.ts` file has been updated to include some new box shadow options.